### PR TITLE
[PI Sprint 25/26] [Enhancement] - Camera Offset Correction and Time-Synchronized TF Lookup

### DIFF
--- a/include/gyakuenki_cpp/node/gyakuenki_cpp_node.hpp
+++ b/include/gyakuenki_cpp/node/gyakuenki_cpp_node.hpp
@@ -26,6 +26,7 @@
 
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -71,6 +72,10 @@ private:
 
   rclcpp::Service<GetCameraOffset>::SharedPtr get_camera_offset_service;
   rclcpp::Service<UpdateCameraOffset>::SharedPtr update_camera_offset_service;
+
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr corrected_camera_publisher;
+
+  rclcpp::TimerBase::SharedPtr node_timer;
 };
 
 }  // namespace gyakuenki_cpp

--- a/include/gyakuenki_cpp/projections/ipm.hpp
+++ b/include/gyakuenki_cpp/projections/ipm.hpp
@@ -78,11 +78,12 @@ public:
   cv::Point2d get_target_pixel(const DetectedObject & detected_object);
   cv::Point2d get_normalized_target_pixel(const DetectedObject & detected_object);
 
-  tf2::Transform get_corrected_camera_transform(const std::string & output_frame);
+  tf2::Transform get_corrected_camera_transform(
+    const std::string & output_frame, const rclcpp::Time & timestamp);
 
   gyakuenki_interfaces::msg::ProjectedObject map_object(
-    const DetectedObject & detected_object, const std::string & output_frame,
-    keisan::Matrix<4, 1> & Pc);
+    const DetectedObject & detected_object, const rclcpp::Time & timestamp,
+    const std::string & output_frame, keisan::Matrix<4, 1> & Pc);
 
   const CameraOffset & get_camera_offset() const { return camera_offset; }
 

--- a/include/gyakuenki_cpp/projections/ipm.hpp
+++ b/include/gyakuenki_cpp/projections/ipm.hpp
@@ -78,6 +78,8 @@ public:
   cv::Point2d get_target_pixel(const DetectedObject & detected_object);
   cv::Point2d get_normalized_target_pixel(const DetectedObject & detected_object);
 
+  tf2::Transform get_corrected_camera_transform(const std::string & output_frame);
+
   gyakuenki_interfaces::msg::ProjectedObject map_object(
     const DetectedObject & detected_object, const std::string & output_frame,
     keisan::Matrix<4, 1> & Pc);
@@ -91,6 +93,7 @@ private:
 
   utils::CameraInfo camera_info;
   CameraOffset camera_offset;
+  tf2::Vector3 translation_offset;
   tf2::Quaternion rotation_offset;
 };
 

--- a/src/gyakuenki_cpp/node/gyakuenki_cpp_node.cpp
+++ b/src/gyakuenki_cpp/node/gyakuenki_cpp_node.cpp
@@ -20,6 +20,8 @@
 
 #include "gyakuenki_cpp/node/gyakuenki_cpp_node.hpp"
 
+using namespace std::chrono_literals;
+
 namespace gyakuenki_cpp
 {
 
@@ -53,7 +55,7 @@ GyakuenkiCppNode::GyakuenkiCppNode(
       try {
         keisan::Matrix<4, 1> Pc;
         ProjectedObject projected_ball =
-          this->ipm->map_object(*message, "base_footprint", Pc);
+          this->ipm->map_object(*message, rclcpp::Time(0), "base_footprint", Pc);
         projected_ball_publisher->publish(projected_ball);
       } catch (std::exception & e) {
         RCLCPP_ERROR(this->node->get_logger(), e.what());
@@ -98,26 +100,24 @@ GyakuenkiCppNode::GyakuenkiCppNode(
   corrected_camera_publisher = node->create_publisher<geometry_msgs::msg::PoseStamped>(
     "gyakuenki_cpp/corrected_camera_pose", 10);
 
-  node_timer = node->create_wall_timer(
-    std::chrono::milliseconds(100), [this]() {
-      try {
-        tf2::Transform tf_final = ipm->get_corrected_camera_transform("base_footprint");
+  node_timer = node->create_wall_timer(8ms, [this]() {
+    try {
+      tf2::Transform tf_final = ipm->get_corrected_camera_transform("base_footprint", rclcpp::Time(0));
 
-        geometry_msgs::msg::PoseStamped camera_pose;
-        camera_pose.header.stamp = this->node->get_clock()->now();
-        camera_pose.header.frame_id = "base_footprint";
-        camera_pose.pose.position.x = tf_final.getOrigin().x();
-        camera_pose.pose.position.y = tf_final.getOrigin().y();
-        camera_pose.pose.position.z = tf_final.getOrigin().z();
-        camera_pose.pose.orientation = ipm->tf2_to_msg(tf_final.getRotation());
+      geometry_msgs::msg::PoseStamped camera_pose;
+      camera_pose.header.stamp = this->node->get_clock()->now();
+      camera_pose.header.frame_id = "base_footprint";
+      camera_pose.pose.position.x = tf_final.getOrigin().x();
+      camera_pose.pose.position.y = tf_final.getOrigin().y();
+      camera_pose.pose.position.z = tf_final.getOrigin().z();
+      camera_pose.pose.orientation = ipm->tf2_to_msg(tf_final.getRotation());
 
-        corrected_camera_publisher->publish(camera_pose);
+      corrected_camera_publisher->publish(camera_pose);
 
-      } catch (const std::exception & ex) {
-        RCLCPP_WARN(this->node->get_logger(), "Could not get corrected camera transform: %s", ex.what());
-      }
+    } catch (const std::exception & ex) {
+      RCLCPP_WARN(this->node->get_logger(), "Could not get corrected camera transform: %s", ex.what());
     }
-  );
+  });
 }
 
 void GyakuenkiCppNode::publish(const DetectedObjects::SharedPtr & message)
@@ -130,7 +130,7 @@ void GyakuenkiCppNode::publish(const DetectedObjects::SharedPtr & message)
     try {
       keisan::Matrix<4, 1> Pc;
       ProjectedObject projected_object =
-        this->ipm->map_object(detected_object, "base_footprint", Pc);
+        this->ipm->map_object(detected_object, message->header.stamp, "base_footprint", Pc);
 
       projected_objects.projected_objects.push_back(projected_object);
 

--- a/src/gyakuenki_cpp/node/gyakuenki_cpp_node.cpp
+++ b/src/gyakuenki_cpp/node/gyakuenki_cpp_node.cpp
@@ -93,6 +93,31 @@ GyakuenkiCppNode::GyakuenkiCppNode(
 
       response->status = true;
     });
+
+  // Publisher for visualizing the corrected camera pose in RViz
+  corrected_camera_publisher = node->create_publisher<geometry_msgs::msg::PoseStamped>(
+    "gyakuenki_cpp/corrected_camera_pose", 10);
+
+  node_timer = node->create_wall_timer(
+    std::chrono::milliseconds(100), [this]() {
+      try {
+        tf2::Transform tf_final = ipm->get_corrected_camera_transform("base_footprint");
+
+        geometry_msgs::msg::PoseStamped camera_pose;
+        camera_pose.header.stamp = this->node->get_clock()->now();
+        camera_pose.header.frame_id = "base_footprint";
+        camera_pose.pose.position.x = tf_final.getOrigin().x();
+        camera_pose.pose.position.y = tf_final.getOrigin().y();
+        camera_pose.pose.position.z = tf_final.getOrigin().z();
+        camera_pose.pose.orientation = ipm->tf2_to_msg(tf_final.getRotation());
+
+        corrected_camera_publisher->publish(camera_pose);
+
+      } catch (const std::exception & ex) {
+        RCLCPP_WARN(this->node->get_logger(), "Could not get corrected camera transform: %s", ex.what());
+      }
+    }
+  );
 }
 
 void GyakuenkiCppNode::publish(const DetectedObjects::SharedPtr & message)

--- a/src/gyakuenki_cpp/projections/ipm.cpp
+++ b/src/gyakuenki_cpp/projections/ipm.cpp
@@ -46,6 +46,9 @@ void IPM::load_config(const std::string & path)
   double roll_double;
   double pitch_double;
   double yaw_double;
+  double x_double;
+  double y_double;
+  double z_double;
 
   nlohmann::json rotation_offset_section;
   if (jitsuyo::assign_val(config, "rotation_offset", rotation_offset_section)) {
@@ -61,19 +64,12 @@ void IPM::load_config(const std::string & path)
     valid_config = false;
   }
 
-  camera_offset.roll = keisan::make_degree(roll_double);
-  camera_offset.pitch = keisan::make_degree(pitch_double);
-  camera_offset.yaw = keisan::make_degree(yaw_double);
-
-  rotation_offset.setRPY(
-    camera_offset.roll.radian(), camera_offset.pitch.radian(), camera_offset.yaw.radian());
-
   nlohmann::json position_offset_section;
   if (jitsuyo::assign_val(config, "position_offset", position_offset_section)) {
     bool valid_section = true;
-    valid_section &= jitsuyo::assign_val(position_offset_section, "x", camera_offset.position.x);
-    valid_section &= jitsuyo::assign_val(position_offset_section, "y", camera_offset.position.y);
-    valid_section &= jitsuyo::assign_val(position_offset_section, "z", camera_offset.position.z);
+    valid_section &= jitsuyo::assign_val(position_offset_section, "x", x_double);
+    valid_section &= jitsuyo::assign_val(position_offset_section, "y", y_double);
+    valid_section &= jitsuyo::assign_val(position_offset_section, "z", z_double);
     if (!valid_section) {
       std::cout << "Error found at section `position_offset`" << std::endl;
       valid_config = false;
@@ -81,6 +77,8 @@ void IPM::load_config(const std::string & path)
   } else {
     valid_config = false;
   }
+
+  set_config(x_double, y_double, z_double, roll_double, pitch_double, yaw_double);
 
   if (!valid_config) {
     throw std::runtime_error("Failed to set configuration file `camera_offset.json`");
@@ -95,6 +93,8 @@ void IPM::set_config(double x, double y, double z, double roll, double pitch, do
   camera_offset.roll = keisan::make_degree(roll);
   camera_offset.pitch = keisan::make_degree(pitch);
   camera_offset.yaw = keisan::make_degree(yaw);
+
+  translation_offset.setValue(x, y, z);
   rotation_offset.setRPY(
     camera_offset.roll.radian(), camera_offset.pitch.radian(), camera_offset.yaw.radian());
 }
@@ -258,6 +258,47 @@ keisan::Matrix<4, 1> IPM::point_in_camera_frame(
   return Pc;
 }
 
+// Apply the camera translation and rotation offset to the transform from camera frame
+// to output frame (e. g. base_footprint) and return the corrected transform
+// Apply offset:
+// T_final = T_base_to_cam * T_offset
+// Also can be done by:
+// - Apply rotation: R_final = R_base_to_cam * R_offset
+// - Apply translation: t_final = R_base_to_cam * t_offset + t_base_to_cam
+tf2::Transform IPM::get_corrected_camera_transform(const std::string & output_frame)
+{
+  // Get the latest transform (Rotation and Translation) from the camera to the output frame
+  geometry_msgs::msg::TransformStamped t;
+  try {
+    t = tf_buffer->lookupTransform(output_frame, camera_info.frame_id, tf2::TimePointZero);
+  } catch (tf2::TransformException & ex) {
+    throw std::runtime_error(ex.what());
+  }
+
+  // Build TF from base to camera
+  tf2::Transform tf_base_to_cam;
+
+  tf2::Quaternion q_base_cam = msg_to_tf2(t.transform.rotation);
+
+  tf_base_to_cam.setOrigin(
+    tf2::Vector3(
+      t.transform.translation.x,
+      t.transform.translation.y,
+      t.transform.translation.z));
+
+  tf_base_to_cam.setRotation(q_base_cam);
+
+  // Build offset transform
+  tf2::Transform tf_offset;
+  tf_offset.setOrigin(translation_offset);
+  tf_offset.setRotation(rotation_offset);
+
+  // Apply offset: T_final = T_base_cam * T_offset
+  tf2::Transform tf_final = tf_base_to_cam * tf_offset;
+
+  return tf_final;
+}
+
 // Map the detected object to the 3D world relative to param output_frame (e. g. base_footprint) using pinhole camera model
 gyakuenki_interfaces::msg::ProjectedObject IPM::map_object(
   const DetectedObject & detected_object, const std::string & output_frame, keisan::Matrix<4, 1> & Pc)
@@ -276,23 +317,22 @@ gyakuenki_interfaces::msg::ProjectedObject IPM::map_object(
   // First, get the normalized target pixel
   cv::Point2d norm_pixel = get_normalized_target_pixel(detected_object);
 
-  // Get the latest transform (Rotation and Translation) from the camera to the output frame
-  geometry_msgs::msg::TransformStamped t;
-  try {
-    t = tf_buffer->lookupTransform(output_frame, camera_info.frame_id, tf2::TimePointZero);
-  } catch (tf2::TransformException & ex) {
-    throw std::runtime_error(ex.what());
-  }
+  // Get the camera transform with offset applied expressed in output_frame (e. g. base_footprint)
+  tf2::Transform tf_final = get_corrected_camera_transform(output_frame);
+
+  // Extract the rotation and translation from the final transform
+  tf2::Quaternion q_final = tf_final.getRotation();
+  tf2::Vector3 t_final = tf_final.getOrigin();
 
   // Convert the quaternion to rotation matrix R
   keisan::Matrix<4, 4> R =
-    quat_to_rotation_matrix(tf2_to_msg(msg_to_tf2(t.transform.rotation) * rotation_offset));
+    quat_to_rotation_matrix(tf2_to_msg(q_final));
 
   // Get the translation matrix
   keisan::Matrix<4, 4> T = keisan::translation_matrix(keisan::Point3(
-    t.transform.translation.x + camera_offset.position.x,
-    t.transform.translation.y + camera_offset.position.y,
-    t.transform.translation.z + camera_offset.position.z));
+    t_final.x(),
+    t_final.y(),
+    t_final.z()));
 
   // Now, we have the 3D point in camera frame
   Pc = point_in_camera_frame(norm_pixel, T, R, detected_object.label);

--- a/src/gyakuenki_cpp/projections/ipm.cpp
+++ b/src/gyakuenki_cpp/projections/ipm.cpp
@@ -265,14 +265,33 @@ keisan::Matrix<4, 1> IPM::point_in_camera_frame(
 // Also can be done by:
 // - Apply rotation: R_final = R_base_to_cam * R_offset
 // - Apply translation: t_final = R_base_to_cam * t_offset + t_base_to_cam
-tf2::Transform IPM::get_corrected_camera_transform(const std::string & output_frame)
+tf2::Transform IPM::get_corrected_camera_transform(
+  const std::string & output_frame, const rclcpp::Time & timestamp)
 {
-  // Get the latest transform (Rotation and Translation) from the camera to the output frame
+  // Get the transform from the camera frame to the output frame at the timestamp when
+  // the image was captured
   geometry_msgs::msg::TransformStamped t;
   try {
-    t = tf_buffer->lookupTransform(output_frame, camera_info.frame_id, tf2::TimePointZero);
-  } catch (tf2::TransformException & ex) {
-    throw std::runtime_error(ex.what());
+    if (timestamp.nanoseconds() == 0) {
+      t = tf_buffer->lookupTransform(
+        output_frame,
+        camera_info.frame_id,
+        tf2::TimePointZero);
+    } else {
+      t = tf_buffer->lookupTransform(
+        output_frame,
+        camera_info.frame_id,
+        timestamp,
+        tf2::Duration::zero()
+      );
+    }
+  } catch (tf2::TransformException &) {
+    try {
+      t = tf_buffer->lookupTransform(output_frame, camera_info.frame_id, tf2::TimePointZero);
+      RCLCPP_WARN(node->get_logger(), "TF not available for capture timestamp, using latest TF");
+    } catch (tf2::TransformException & ex) {
+      throw std::runtime_error(ex.what());
+    }
   }
 
   // Build TF from base to camera
@@ -301,7 +320,8 @@ tf2::Transform IPM::get_corrected_camera_transform(const std::string & output_fr
 
 // Map the detected object to the 3D world relative to param output_frame (e. g. base_footprint) using pinhole camera model
 gyakuenki_interfaces::msg::ProjectedObject IPM::map_object(
-  const DetectedObject & detected_object, const std::string & output_frame, keisan::Matrix<4, 1> & Pc)
+  const DetectedObject & detected_object, const rclcpp::Time & timestamp,
+  const std::string & output_frame, keisan::Matrix<4, 1> & Pc)
 {
   // The relationship between 3D world points Pw = [Xw, Yw, Zw, 1] and 2D image pixels p = [u, v, 1] is given by:
   // p = K * [R | T] * Pw
@@ -318,7 +338,7 @@ gyakuenki_interfaces::msg::ProjectedObject IPM::map_object(
   cv::Point2d norm_pixel = get_normalized_target_pixel(detected_object);
 
   // Get the camera transform with offset applied expressed in output_frame (e. g. base_footprint)
-  tf2::Transform tf_final = get_corrected_camera_transform(output_frame);
+  tf2::Transform tf_final = get_corrected_camera_transform(output_frame, timestamp);
 
   // Extract the rotation and translation from the final transform
   tf2::Quaternion q_final = tf_final.getRotation();


### PR DESCRIPTION
## Jira Link: 

## Description

Fix the camera offset calculation and publish the corrected camera position for visualization and debugging (in RViz).
The previous code applied the translation in the global frame, but it supposed to be applied in the local camera frame.

Use the detection timestamp (image capture time) to perform a time-synchronized TF lookup from tf_buffer.

## Type of Change

- [x] Bugfix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [x] Manual tested.

## Checklist:

- [x] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.