### PR TITLE
[PI Sprint 25/26] [Enhancement] - Publish Bounding Boxes

### DIFF
--- a/include/gyakuenki_cpp/node/gyakuenki_cpp_node.hpp
+++ b/include/gyakuenki_cpp/node/gyakuenki_cpp_node.hpp
@@ -31,6 +31,7 @@
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include "gyakuenki_cpp/projections/ipm.hpp"
+#include "gyakuenki_interfaces/msg/point3.hpp"
 #include "gyakuenki_interfaces/msg/projected_object.hpp"
 #include "gyakuenki_interfaces/msg/projected_objects.hpp"
 #include "gyakuenki_interfaces/srv/get_camera_offset.hpp"
@@ -48,6 +49,7 @@ public:
   using Marker = visualization_msgs::msg::Marker;
   using DetectedObject = ninshiki_interfaces::msg::DetectedObject;
   using DetectedObjects = ninshiki_interfaces::msg::DetectedObjects;
+  using Point3 = gyakuenki_interfaces::msg::Point3;
   using ProjectedObjects = gyakuenki_interfaces::msg::ProjectedObjects;
   using ProjectedObject = gyakuenki_interfaces::msg::ProjectedObject;
   using GetCameraOffset = gyakuenki_interfaces::srv::GetCameraOffset;

--- a/include/gyakuenki_cpp/projections/ipm.hpp
+++ b/include/gyakuenki_cpp/projections/ipm.hpp
@@ -32,6 +32,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include "gyakuenki_cpp/utils/camera_info.hpp"
+#include "gyakuenki_interfaces/msg/point3.hpp"
 #include "gyakuenki_interfaces/msg/projected_object.hpp"
 #include "keisan/matrix.hpp"
 #include "ninshiki_interfaces/msg/detected_object.hpp"
@@ -81,7 +82,7 @@ public:
   tf2::Transform get_corrected_camera_transform(
     const std::string & output_frame, const rclcpp::Time & timestamp);
 
-  gyakuenki_interfaces::msg::ProjectedObject map_object(
+  gyakuenki_interfaces::msg::Point3 map_object(
     const DetectedObject & detected_object, const rclcpp::Time & timestamp,
     const std::string & output_frame, keisan::Matrix<4, 1> & Pc);
 

--- a/src/gyakuenki_cpp/node/gyakuenki_cpp_node.cpp
+++ b/src/gyakuenki_cpp/node/gyakuenki_cpp_node.cpp
@@ -110,12 +110,22 @@ void GyakuenkiCppNode::publish(const DetectedObjects::SharedPtr & message)
 
   uint8_t id = 0;
   for (const auto & detected_object : message->detected_objects) {
+    ProjectedObject projected_object;
+
+    projected_object.label = detected_object.label;
+    projected_object.confidence = detected_object.score;
+    projected_object.left = detected_object.left;
+    projected_object.top = detected_object.top;
+    projected_object.right = detected_object.right;
+    projected_object.bottom = detected_object.bottom;
+    projected_object.has_projection = true;
+
     try {
       keisan::Matrix<4, 1> Pc;
-      ProjectedObject projected_object =
+      Point3 position =
         this->ipm->map_object(detected_object, message->header.stamp, "base_footprint", Pc);
 
-      projected_objects.projected_objects.push_back(projected_object);
+      projected_object.position = position;
 
       Marker marker;
       marker.header.frame_id = "camera";
@@ -173,8 +183,11 @@ void GyakuenkiCppNode::publish(const DetectedObjects::SharedPtr & message)
 
       markers.markers.push_back(marker);
     } catch (std::exception & e) {
-      RCLCPP_ERROR(this->node->get_logger(), e.what());
+      projected_object.has_projection = false;
+      RCLCPP_WARN(this->node->get_logger(), e.what());
     }
+
+    projected_objects.projected_objects.push_back(projected_object);
   }
 
   projected_objects_publisher->publish(projected_objects);

--- a/src/gyakuenki_cpp/node/gyakuenki_cpp_node.cpp
+++ b/src/gyakuenki_cpp/node/gyakuenki_cpp_node.cpp
@@ -40,28 +40,11 @@ GyakuenkiCppNode::GyakuenkiCppNode(
   projected_objects_publisher =
     node->create_publisher<ProjectedObjects>("gyakuenki_cpp/projected_objects", 10);
 
-  projected_ball_publisher =
-    node->create_publisher<ProjectedObject>("gyakuenki_cpp/projected_ball", 10);
-
   markers_publisher = node->create_publisher<MarkerArray>("gyakuenki_cpp/markers", 10);
 
   dnn_detection_subscriber = node->create_subscription<DetectedObjects>(
     "ninshiki_cpp/dnn_detection", 10,
     [this](const DetectedObjects::SharedPtr message) { this->publish(message); });
-
-  ball_detection_subscriber = node->create_subscription<DetectedObject>(
-    "soccer/ball_detection", 10,
-    [this](const DetectedObject::SharedPtr message) {
-      try {
-        keisan::Matrix<4, 1> Pc;
-        ProjectedObject projected_ball =
-          this->ipm->map_object(*message, rclcpp::Time(0), "base_footprint", Pc);
-        projected_ball_publisher->publish(projected_ball);
-      } catch (std::exception & e) {
-        RCLCPP_ERROR(this->node->get_logger(), e.what());
-      }
-    }
-  );
 
   // Camera Offset Services
   get_camera_offset_service = node->create_service<GetCameraOffset>(

--- a/src/gyakuenki_cpp/node/gyakuenki_cpp_node.cpp
+++ b/src/gyakuenki_cpp/node/gyakuenki_cpp_node.cpp
@@ -85,7 +85,8 @@ GyakuenkiCppNode::GyakuenkiCppNode(
 
   node_timer = node->create_wall_timer(8ms, [this]() {
     try {
-      tf2::Transform tf_final = ipm->get_corrected_camera_transform("base_footprint", rclcpp::Time(0));
+      tf2::Transform tf_final =
+        ipm->get_corrected_camera_transform("base_footprint", rclcpp::Time(0));
 
       geometry_msgs::msg::PoseStamped camera_pose;
       camera_pose.header.stamp = this->node->get_clock()->now();
@@ -98,7 +99,8 @@ GyakuenkiCppNode::GyakuenkiCppNode(
       corrected_camera_publisher->publish(camera_pose);
 
     } catch (const std::exception & ex) {
-      RCLCPP_WARN(this->node->get_logger(), "Could not get corrected camera transform: %s", ex.what());
+      RCLCPP_WARN(
+        this->node->get_logger(), "Could not get corrected camera transform: %s", ex.what());
     }
   });
 }
@@ -118,7 +120,7 @@ void GyakuenkiCppNode::publish(const DetectedObjects::SharedPtr & message)
     projected_object.top = detected_object.top;
     projected_object.right = detected_object.right;
     projected_object.bottom = detected_object.bottom;
-    projected_object.has_projection = true;
+    projected_object.has_projection = false;
 
     try {
       keisan::Matrix<4, 1> Pc;
@@ -126,6 +128,7 @@ void GyakuenkiCppNode::publish(const DetectedObjects::SharedPtr & message)
         this->ipm->map_object(detected_object, message->header.stamp, "base_footprint", Pc);
 
       projected_object.position = position;
+      projected_object.has_projection = true;
 
       Marker marker;
       marker.header.frame_id = "camera";
@@ -183,7 +186,6 @@ void GyakuenkiCppNode::publish(const DetectedObjects::SharedPtr & message)
 
       markers.markers.push_back(marker);
     } catch (std::exception & e) {
-      projected_object.has_projection = false;
       RCLCPP_WARN(this->node->get_logger(), e.what());
     }
 

--- a/src/gyakuenki_cpp/projections/ipm.cpp
+++ b/src/gyakuenki_cpp/projections/ipm.cpp
@@ -374,6 +374,10 @@ gyakuenki_interfaces::msg::ProjectedObject IPM::map_object(
   projected_object.position.y = Pw[1][0];
   projected_object.position.z = Pw[2][0];
   projected_object.confidence = detected_object.score;
+  projected_object.left = detected_object.left;
+  projected_object.top = detected_object.top;
+  projected_object.right = detected_object.right;
+  projected_object.bottom = detected_object.bottom;
 
   return projected_object;
 }

--- a/src/gyakuenki_cpp/projections/ipm.cpp
+++ b/src/gyakuenki_cpp/projections/ipm.cpp
@@ -319,7 +319,7 @@ tf2::Transform IPM::get_corrected_camera_transform(
 }
 
 // Map the detected object to the 3D world relative to param output_frame (e. g. base_footprint) using pinhole camera model
-gyakuenki_interfaces::msg::ProjectedObject IPM::map_object(
+gyakuenki_interfaces::msg::Point3 IPM::map_object(
   const DetectedObject & detected_object, const rclcpp::Time & timestamp,
   const std::string & output_frame, keisan::Matrix<4, 1> & Pc)
 {
@@ -367,19 +367,12 @@ gyakuenki_interfaces::msg::ProjectedObject IPM::map_object(
   keisan::Matrix<4, 1> Pw = M * Pc;
 
   // Create the ProjectedObject instance
-  gyakuenki_interfaces::msg::ProjectedObject projected_object;
+  gyakuenki_interfaces::msg::Point3 position;
+  position.x = Pw[0][0];
+  position.y = Pw[1][0];
+  position.z = Pw[2][0];
 
-  projected_object.label = detected_object.label;
-  projected_object.position.x = Pw[0][0];
-  projected_object.position.y = Pw[1][0];
-  projected_object.position.z = Pw[2][0];
-  projected_object.confidence = detected_object.score;
-  projected_object.left = detected_object.left;
-  projected_object.top = detected_object.top;
-  projected_object.right = detected_object.right;
-  projected_object.bottom = detected_object.bottom;
-
-  return projected_object;
+  return position;
 }
 
 }  // namespace gyakuenki_cpp


### PR DESCRIPTION
## Jira Link: 

## Description

Forward bounding box detections from `ninshiki` to `ProjectedObjects`. This enables `soccer` to select either `/ninshiki_cpp/dnn_detection` or `/gyakuenki_cpp/projected_objects`.

## Type of Change

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [x] Manual tested.

## Checklist:

- [x] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.